### PR TITLE
fix: Add Missing Themes Moonlight & Dracula

### DIFF
--- a/src-web/lib/theme/themes.ts
+++ b/src-web/lib/theme/themes.ts
@@ -1,9 +1,11 @@
 import type { Appearance } from './appearance';
 import { resolveAppearance } from './appearance';
 import { catppuccin } from './themes/catppuccin';
+import { dracula } from './themes/dracula';
 import { github } from './themes/github';
 import { hotdogStand } from './themes/hotdog-stand';
 import { monokaiPro } from './themes/monokai-pro';
+import { moonlight } from './themes/moonlight';
 import { relaxing } from './themes/relaxing';
 import { rosePine } from './themes/rose-pine';
 import { yaak, yaakDark, yaakLight } from './themes/yaak';
@@ -15,10 +17,12 @@ export const defaultLightTheme = yaakLight;
 const allThemes = [
   ...yaak,
   ...catppuccin,
+  ...dracula,
   ...relaxing,
   ...rosePine,
   ...github,
   ...monokaiPro,
+  ...moonlight,
   ...hotdogStand,
 ];
 


### PR DESCRIPTION
While working on #132, I discovered that the **Moonlight** and **Dracula** themes, although present in the `themes/` folder, were not registered in `themes.ts` resulting in these themes being unavailable in the app.

#### Changes Introduced:
1. Registered the **Moonlight** and **Dracula** themes in `themes.ts` to make them accessible in the application.

#### Testing:
1. Verify that both **Moonlight** and **Dracula** themes are now available in the theme selection menu.

This small fix restores the availability of these themes, ensuring users can enjoy them as intended.

Thank you for reviewing this PR!



